### PR TITLE
`@PublicInit` ignores static properties

### DIFF
--- a/Sources/MacroKitMacros/PublicInitMacro.swift
+++ b/Sources/MacroKitMacros/PublicInitMacro.swift
@@ -30,6 +30,8 @@ public struct PublicInitMacro: MemberMacro {
         var included: [VariableDeclSyntax] = []
 
         for property in structDecl.storedProperties {
+            guard !property.isStatic else { continue }
+
             if property.type != nil {
                 included.append(property)
             } else {

--- a/Tests/MacroKitTests/PublicInitMacroTests.swift
+++ b/Tests/MacroKitTests/PublicInitMacroTests.swift
@@ -60,6 +60,30 @@ final class PublicInitMacroTests: XCTestCase {
             macros: testMacros
         )
     }
+    func testPublicInit_HappyPath_IgnoreStaticProperties() {
+        assertMacroExpansion(
+            """
+            @PublicInit
+            public struct Foo {
+                static var a: Int = 0
+                let b: Double
+            }
+            """,
+            expandedSource: """
+
+            public struct Foo {
+                static var a: Int = 0
+                let b: Double
+                public init(
+                    b: Double
+                ) {
+                    self.b = b
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
     func testPublicInit_Failure_AccessPrivate() {
         assertMacroExpansion(
             """


### PR DESCRIPTION
Thank you for providing this wonderful OSS. While trying it out, I discovered an unintended behavior with the `@PublicInit` macro. I would like to propose an improvement, could you please review it?

### Problem
Static properties must not appear in the public initializer generated by `@PublicInit` macro.

When I write a test code like the following:
```swift
func testPublicInit_HappyPath_IgnoreStaticProperties() {
    assertMacroExpansion(
        """
        @PublicInit
        public struct Foo {
            static var a: Int = 0
            let b: Double
        }
        """,
        expandedSource: """

        public struct Foo {
            static var a: Int = 0
            let b: Double
            public init(
                b: Double
            ) {
                self.b = b
            }
        }
        """,
        macros: testMacros
    )
}
```

the test fails with the error message below:
```diff
failed - Actual output (+) differed from expected output (-):
 
 public struct Foo {
     static var a: Int = 0
     let b: Double
     public init(
+        a: Int = 0,
         b: Double
     ) {
+        self.a = a
         self.b = b
     }
 }
```


### Proposal
Stop appending static properties to the variable `included` using pre-defined `isStatic`.