### PR TITLE
Adding ability to support internal types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,33 @@
 {
+  "originHash" : "fa560f8b7bc8d1cda35d348ac46126be6dfb2260ec3d04565f2cf9bf3513ff29",
   "pins" : [
+    {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "a35257b7e9ce44e92636447003a8eeefb77b145c",
+        "version" : "0.5.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
+        "version" : "1.17.2"
+      }
+    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version: 5.9
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 5.10
 
 import PackageDescription
 import CompilerPluginSupport

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ let package = Package(
     name: "MacroKit",
     platforms: [.macOS(.v10_15), .iOS(.v13)],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "MacroKit",
             targets: ["MacroKit"]
@@ -18,10 +17,10 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"511.0.0"),
     ],
     targets: [
-        // Macro implementation that performs the source transformation of a macro.
         .macro(
             name: "MacroKitMacros",
             dependencies: [
@@ -42,6 +41,7 @@ let package = Package(
             dependencies: [
                 "MacroKitMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "MacroTesting", package: "swift-macro-testing"),
             ]
         ),
     ]

--- a/Sources/MacroKitClient/GenerateMock.swift
+++ b/Sources/MacroKitClient/GenerateMock.swift
@@ -25,3 +25,12 @@ protocol DependencyC {
 
     func convert(_ input: Input) async throws -> Output
 }
+
+// Internal Types
+
+struct Qux { } // non-public
+
+@GenerateMock
+protocol DependencyD {
+    var qux: Qux { get }
+}

--- a/Sources/MacroKitMacros/Support/AccessLevelSyntax.swift
+++ b/Sources/MacroKitMacros/Support/AccessLevelSyntax.swift
@@ -42,6 +42,7 @@ extension StructDeclSyntax: AccessLevelSyntax { }
 extension ClassDeclSyntax: AccessLevelSyntax { }
 extension EnumDeclSyntax: AccessLevelSyntax { }
 extension ActorDeclSyntax: AccessLevelSyntax { }
+extension ProtocolDeclSyntax: AccessLevelSyntax { }
 
 extension FunctionDeclSyntax: AccessLevelSyntax { }
 extension VariableDeclSyntax: AccessLevelSyntax { }

--- a/Sources/MacroKitMacros/Support/Extensions.swift
+++ b/Sources/MacroKitMacros/Support/Extensions.swift
@@ -34,6 +34,9 @@ extension FunctionDeclSyntax {
     public var isAsync: Bool {
         return signature.effectSpecifiers?.asyncSpecifier != nil
     }
+    public var isStatic: Bool {
+        return modifiers.lazy.contains(where: { $0.name.tokenKind == .keyword(.static) }) == true
+    }
 }
 
 extension FunctionParameterListSyntax {

--- a/Tests/MacroKitTests/GenerateMockMacroTests.swift
+++ b/Tests/MacroKitTests/GenerateMockMacroTests.swift
@@ -1,7 +1,8 @@
+import MacroKitMacros
+import MacroTesting
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
-import MacroKitMacros
 
 private let testMacros: [String: Macro.Type] = [
     "GenerateMock": GenerateMockMacro.self,
@@ -10,7 +11,14 @@ private let testMacros: [String: Macro.Type] = [
 // edges cases:
 //  - overloaded functions
 
-final class GenerateMockMacroTests: XCTestCase {
+class GenerateMockMacroTests: XCTestCase {
+
+    override func invokeTest() {
+        withMacroTesting(macros: [GenerateMockMacro.self]) {
+            super.invokeTest()
+        }
+    }
+
     func testGenerateMock_HappyPath_SimpleProperty() {
         let proto = """
         protocol TestProtocol {
@@ -19,14 +27,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: String {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -48,9 +60,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ThrowingProperty() {
         let proto = """
@@ -60,14 +71,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: String {
+                    get throws
+                }
+            }
 
             #if DEBUG
 
@@ -86,9 +101,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_AsyncProperty() {
         let proto = """
@@ -98,14 +112,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: String {
+                    get async
+                }
+            }
 
             #if DEBUG
 
@@ -124,9 +142,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_AsyncThrowingProperty() {
         let proto = """
@@ -136,14 +153,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: String {
+                    get async throws
+                }
+            }
 
             #if DEBUG
 
@@ -162,9 +183,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_SimpleProperty_GetSet() {
         let proto = """
@@ -175,14 +195,19 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: String {
+                    get
+                    set
+                }
+            }
 
             #if DEBUG
 
@@ -204,9 +229,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_ClosureProperty_Void() {
@@ -217,14 +241,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: () -> Void {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -246,9 +274,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ClosureProperty_OneParam() {
         let proto = """
@@ -258,14 +285,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: (Int) -> Void {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -287,9 +318,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ClosureProperty_TwoParam() {
         let proto = """
@@ -299,14 +329,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: (Int, Bool) -> Void {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -328,9 +362,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_ThrowingClosureProperty_TwoParam() {
@@ -341,14 +374,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: (Int, Bool) throws -> Void {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -370,9 +407,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ThrowingAsyncClosureProperty_TwoParam() {
         let proto = """
@@ -382,14 +418,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: (Int, Bool) async throws -> Void {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -411,9 +451,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_ImplicitVoidFunction() {
@@ -422,14 +461,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function()
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function()
+            }
 
             #if DEBUG
 
@@ -446,9 +487,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ExplicitVoidFunction() {
         let proto = """
@@ -456,14 +496,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function() -> Void
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function() -> Void
+            }
 
             #if DEBUG
 
@@ -480,9 +522,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ImplicitVoidFunction_WithParam() {
         let proto = """
@@ -490,14 +531,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(value: Int)
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(value: Int)
+            }
 
             #if DEBUG
 
@@ -514,9 +557,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ExplicitVoidFunction_WithParam() {
         let proto = """
@@ -524,14 +566,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(value: Int) -> Void
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(value: Int) -> Void
+            }
 
             #if DEBUG
 
@@ -548,9 +592,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_NonVoidFunction_WithAnonParam() {
@@ -559,14 +602,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(_ value: Int) -> Bool
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(_ value: Int) -> Bool
+            }
 
             #if DEBUG
 
@@ -583,9 +628,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_NonVoidFunction_WithInternalAndExternalParams() {
         let proto = """
@@ -593,14 +637,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(with value: Int) -> Bool
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(with value: Int) -> Bool
+            }
 
             #if DEBUG
 
@@ -617,9 +663,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_ClosureFunction_WithAnonParam() {
@@ -628,14 +673,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(_ value: Int) -> () -> Void
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(_ value: Int) -> () -> Void
+            }
 
             #if DEBUG
 
@@ -652,9 +699,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_ClosureFunctionWithParam_WithAnonParam() {
         let proto = """
@@ -662,14 +708,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(_ value: Int) -> (Bool) -> Void
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(_ value: Int) -> (Bool) -> Void
+            }
 
             #if DEBUG
 
@@ -686,9 +734,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_ThrowingFunction() {
@@ -697,14 +744,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function() throws
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function() throws
+            }
 
             #if DEBUG
 
@@ -721,9 +770,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_AsyncFunction() {
         let proto = """
@@ -731,14 +779,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function() async
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function() async
+            }
 
             #if DEBUG
 
@@ -755,9 +805,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_AsyncThrowingFunction() {
         let proto = """
@@ -765,14 +814,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function() async throws
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function() async throws
+            }
 
             #if DEBUG
 
@@ -789,9 +840,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_AsyncThrowingFunctionWithBothParamsAndReturnType() {
         let proto = """
@@ -799,14 +849,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(with value: Bool) async throws -> String
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(with value: Bool) async throws -> String
+            }
 
             #if DEBUG
 
@@ -823,9 +875,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_FunctionWithParamsWithAttributes() {
@@ -834,14 +885,16 @@ final class GenerateMockMacroTests: XCTestCase {
             func function(_ closure: @Sendable @escaping (Bool) -> Void) async throws -> String
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                func function(_ closure: @Sendable @escaping (Bool) -> Void) async throws -> String
+            }
 
             #if DEBUG
 
@@ -858,9 +911,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_AssociatedType() {
@@ -873,14 +925,20 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                associatedtype Value
 
-            \(proto)
+                var property: Value {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -902,9 +960,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_AssociatedTypeWithConstraint() {
         let proto = """
@@ -916,14 +973,20 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                associatedtype Value: Codable
 
-            \(proto)
+                var property: Value {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -945,9 +1008,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_MultipleAssociatedTypes() {
         let proto = """
@@ -956,14 +1018,17 @@ final class GenerateMockMacroTests: XCTestCase {
             associatedtype Bar: Codable
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                associatedtype Foo
+                associatedtype Bar: Codable
+            }
 
             #if DEBUG
 
@@ -976,9 +1041,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testGenerateMock_HappyPath_Inheritance() {
@@ -989,14 +1053,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol: Equatable {
+                var property: String {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -1018,9 +1086,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
     func testGenerateMock_HappyPath_MultipleInheritance() {
         let proto = """
@@ -1030,14 +1097,18 @@ final class GenerateMockMacroTests: XCTestCase {
             }
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol: Equatable, Codable {
+                var property: String {
+                    get
+                }
+            }
 
             #if DEBUG
 
@@ -1059,9 +1130,8 @@ final class GenerateMockMacroTests: XCTestCase {
             }
 
             #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func _testGenerateMock_HappyPath_OverloadedFunctions() {
@@ -1071,24 +1141,11 @@ final class GenerateMockMacroTests: XCTestCase {
             func function() -> Int
         }
         """
-        assertMacroExpansion(
+        assertMacro {
             """
             @GenerateMock
             \(proto)
-            """,
-            expandedSource: """
-
-            \(proto)
-
-            #if DEBUG
-
-            open class TestProtocolMock: TestProtocol {
-                // TODO
-            }
-
-            #endif
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 }

--- a/Tests/MacroKitTests/GenerateMockMacroTests.swift
+++ b/Tests/MacroKitTests/GenerateMockMacroTests.swift
@@ -1148,4 +1148,110 @@ class GenerateMockMacroTests: XCTestCase {
             """
         }
     }
+
+    func testGenerateMock_whenInternalProtocol_allMockPropertiesAndFunctionsAreMadeInternal() {
+        let proto = """
+        protocol TestProtocol {
+            var property: String { get set }
+            func doWork() -> Int
+            static func doMoreWork() -> String
+        }
+        """
+
+        assertMacro {
+            """
+            @GenerateMock
+            \(proto)
+            """
+        } expansion: {
+            """
+            protocol TestProtocol {
+                var property: String { get set }
+                func doWork() -> Int
+                static func doMoreWork() -> String
+            }
+
+            #if DEBUG
+
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, String> = .init()
+                    internal var doWork: MockMember<(), Int> = .init()
+                    internal var doMoreWork: MockMember<(), String> = .init()
+                }
+                internal var property: String {
+                    get  {
+                        mocks.property.getter()
+                    }
+                    set {
+                        mocks.property.setter(newValue)
+                    }
+                }
+                internal func doWork() -> Int {
+                    return mocks.doWork.execute(())
+                }
+                static internal func doMoreWork() -> String {
+                    return mocks.doMoreWork.execute(())
+                }
+            }
+
+            #endif
+            """
+        }
+    }
+
+    func testGenerateMock_whenPublicProtocol_allMockPropertiesAndFunctionsAreMadePublic() {
+        let proto = """
+        public protocol TestProtocol {
+            var property: String { get set }
+            func doWork() -> Int
+            static func doMoreWork() -> String
+        }
+        """
+
+        assertMacro {
+            """
+            @GenerateMock
+            \(proto)
+            """
+        } expansion: {
+            """
+            public protocol TestProtocol {
+                var property: String { get set }
+                func doWork() -> Int
+                static func doMoreWork() -> String
+            }
+
+            #if DEBUG
+
+            open class TestProtocolMock: TestProtocol {
+                public let mocks = Members()
+                public class Members {
+                    public var property: MockMember<String, String> = .init()
+                    public var doWork: MockMember<(), Int> = .init()
+                    public var doMoreWork: MockMember<(), String> = .init()
+                }
+                public init() {
+                }
+                open var property: String {
+                    get  {
+                        mocks.property.getter()
+                    }
+                    set {
+                        mocks.property.setter(newValue)
+                    }
+                }
+                open func doWork() -> Int {
+                    return mocks.doWork.execute(())
+                }
+                static public func doMoreWork() -> String {
+                    return mocks.doMoreWork.execute(())
+                }
+            }
+
+            #endif
+            """
+        }
+    }
 }

--- a/Tests/MacroKitTests/GenerateMockMacroTests.swift
+++ b/Tests/MacroKitTests/GenerateMockMacroTests.swift
@@ -4,17 +4,13 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-private let testMacros: [String: Macro.Type] = [
-    "GenerateMock": GenerateMockMacro.self,
-]
-
 // edges cases:
 //  - overloaded functions
 
 class GenerateMockMacroTests: XCTestCase {
 
     override func invokeTest() {
-        withMacroTesting(macros: [GenerateMockMacro.self]) {
+        withMacroTesting(record: false, macros: [GenerateMockMacro.self]) {
             super.invokeTest()
         }
     }
@@ -42,14 +38,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, String> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, String> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get {
                         mocks.property.getter()
                     }
@@ -86,14 +80,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, Result<String, Error>> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, Result<String, Error>> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get throws {
                         try mocks.property.getter()
                     }
@@ -127,14 +119,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, String> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, String> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get async {
                         mocks.property.getter()
                     }
@@ -168,14 +158,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, Result<String, Error>> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, Result<String, Error>> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get async throws {
                         try mocks.property.getter()
                     }
@@ -211,14 +199,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, String> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, String> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get {
                         mocks.property.getter()
                     }
@@ -256,14 +242,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<() -> Void, () -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<() -> Void, () -> Void> = .init()
                 }
-                public init() {
-                }
-                open var property: () -> Void {
+                internal var property: () -> Void {
                     get {
                         mocks.property.getter()
                     }
@@ -300,14 +284,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<(Int) -> Void, (Int) -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<(Int) -> Void, (Int) -> Void> = .init()
                 }
-                public init() {
-                }
-                open var property: (Int) -> Void {
+                internal var property: (Int) -> Void {
                     get {
                         mocks.property.getter()
                     }
@@ -344,14 +326,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<(Int, Bool) -> Void, (Int, Bool) -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<(Int, Bool) -> Void, (Int, Bool) -> Void> = .init()
                 }
-                public init() {
-                }
-                open var property: (Int, Bool) -> Void {
+                internal var property: (Int, Bool) -> Void {
                     get {
                         mocks.property.getter()
                     }
@@ -389,14 +369,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<(Int, Bool) throws -> Void, (Int, Bool) throws -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<(Int, Bool) throws -> Void, (Int, Bool) throws -> Void> = .init()
                 }
-                public init() {
-                }
-                open var property: (Int, Bool) throws -> Void {
+                internal var property: (Int, Bool) throws -> Void {
                     get {
                         mocks.property.getter()
                     }
@@ -433,14 +411,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<(Int, Bool) async throws -> Void, (Int, Bool) async throws -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<(Int, Bool) async throws -> Void, (Int, Bool) async throws -> Void> = .init()
                 }
-                public init() {
-                }
-                open var property: (Int, Bool) async throws -> Void {
+                internal var property: (Int, Bool) async throws -> Void {
                     get {
                         mocks.property.getter()
                     }
@@ -474,14 +450,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(), Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(), Void> = .init()
                 }
-                public init() {
-                }
-                open func function() {
+                internal func function() {
                     return mocks.function.execute(())
                 }
             }
@@ -509,14 +483,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(), Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(), Void> = .init()
                 }
-                public init() {
-                }
-                open func function() -> Void {
+                internal func function() -> Void {
                     return mocks.function.execute(())
                 }
             }
@@ -544,14 +516,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Int), Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Int), Void> = .init()
                 }
-                public init() {
-                }
-                open func function(value arg0: Int) {
+                internal func function(value arg0: Int) {
                     return mocks.function.execute((arg0))
                 }
             }
@@ -579,14 +549,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Int), Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Int), Void> = .init()
                 }
-                public init() {
-                }
-                open func function(value arg0: Int) -> Void {
+                internal func function(value arg0: Int) -> Void {
                     return mocks.function.execute((arg0))
                 }
             }
@@ -615,14 +583,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Int), Bool> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Int), Bool> = .init()
                 }
-                public init() {
-                }
-                open func function(_ arg0: Int) -> Bool {
+                internal func function(_ arg0: Int) -> Bool {
                     return mocks.function.execute((arg0))
                 }
             }
@@ -650,14 +616,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Int), Bool> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Int), Bool> = .init()
                 }
-                public init() {
-                }
-                open func function(with arg0: Int) -> Bool {
+                internal func function(with arg0: Int) -> Bool {
                     return mocks.function.execute((arg0))
                 }
             }
@@ -686,14 +650,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Int), () -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Int), () -> Void> = .init()
                 }
-                public init() {
-                }
-                open func function(_ arg0: Int) -> () -> Void {
+                internal func function(_ arg0: Int) -> () -> Void {
                     return mocks.function.execute((arg0))
                 }
             }
@@ -721,14 +683,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Int), (Bool) -> Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Int), (Bool) -> Void> = .init()
                 }
-                public init() {
-                }
-                open func function(_ arg0: Int) -> (Bool) -> Void {
+                internal func function(_ arg0: Int) -> (Bool) -> Void {
                     return mocks.function.execute((arg0))
                 }
             }
@@ -757,14 +717,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(), Result<Void, Error>> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(), Result<Void, Error>> = .init()
                 }
-                public init() {
-                }
-                open func function() throws {
+                internal func function() throws {
                     return try mocks.function.execute(())
                 }
             }
@@ -792,14 +750,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(), Void> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(), Void> = .init()
                 }
-                public init() {
-                }
-                open func function() async {
+                internal func function() async {
                     return mocks.function.execute(())
                 }
             }
@@ -827,14 +783,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(), Result<Void, Error>> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(), Result<Void, Error>> = .init()
                 }
-                public init() {
-                }
-                open func function() async throws {
+                internal func function() async throws {
                     return try mocks.function.execute(())
                 }
             }
@@ -862,14 +816,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<(Bool), Result<String, Error>> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<(Bool), Result<String, Error>> = .init()
                 }
-                public init() {
-                }
-                open func function(with arg0: Bool) async throws -> String {
+                internal func function(with arg0: Bool) async throws -> String {
                     return try mocks.function.execute((arg0))
                 }
             }
@@ -898,14 +850,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var function: MockMember<((Bool) -> Void), Result<String, Error>> = .init()
+            internal class TestProtocolMock: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var function: MockMember<((Bool) -> Void), Result<String, Error>> = .init()
                 }
-                public init() {
-                }
-                open func function(_ arg0: @Sendable @escaping (Bool) -> Void) async throws -> String {
+                internal func function(_ arg0: @Sendable @escaping (Bool) -> Void) async throws -> String {
                     return try mocks.function.execute((arg0))
                 }
             }
@@ -942,14 +892,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock<Value>: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<Value, Value> = .init()
+            internal class TestProtocolMock<Value>: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<Value, Value> = .init()
                 }
-                public init() {
-                }
-                open var property: Value {
+                internal var property: Value {
                     get {
                         mocks.property.getter()
                     }
@@ -990,14 +938,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock<Value: Codable>: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<Value, Value> = .init()
+            internal class TestProtocolMock<Value: Codable>: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<Value, Value> = .init()
                 }
-                public init() {
-                }
-                open var property: Value {
+                internal var property: Value {
                     get {
                         mocks.property.getter()
                     }
@@ -1032,11 +978,9 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock<Foo, Bar: Codable>: TestProtocol {
-                public let mocks = Members()
-                public class Members {
-                }
-                public init() {
+            internal class TestProtocolMock<Foo, Bar: Codable>: TestProtocol {
+                internal let mocks = Members()
+                internal class Members {
                 }
             }
 
@@ -1068,14 +1012,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol, Equatable {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, String> = .init()
+            internal class TestProtocolMock: TestProtocol, Equatable {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, String> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get {
                         mocks.property.getter()
                     }
@@ -1112,14 +1054,12 @@ class GenerateMockMacroTests: XCTestCase {
 
             #if DEBUG
 
-            open class TestProtocolMock: TestProtocol, Equatable, Codable {
-                public let mocks = Members()
-                public class Members {
-                    public var property: MockMember<String, String> = .init()
+            internal class TestProtocolMock: TestProtocol, Equatable, Codable {
+                internal let mocks = Members()
+                internal class Members {
+                    internal var property: MockMember<String, String> = .init()
                 }
-                public init() {
-                }
-                open var property: String {
+                internal var property: String {
                     get {
                         mocks.property.getter()
                     }


### PR DESCRIPTION
# Overview

Protocols that aren't public, and that also don't use public types cannot be compiled with the current macro.

```swift
struct Qux { } // non-public

@GenerateMock
protocol DependencyD {
    var qux: Qux { get }
}

// Expanded Macro
#if DEBUG

open class DependencyDMock: DependencyD {
    public let mocks = Members()
    public class Members {
        public var qux: MockMember<Qux, Qux> = .init() // ERROR Property cannot be declared public because its type uses an internal type
    }
    public init() {
    }
    open var qux: Qux { // ERROR Property cannot be declared public because its type uses an 
        get  {
            mocks.qux.getter()
        }
        set {
            mocks.qux.setter(newValue)
        }
    }
}

#endif
```

This PR add a check for the access modifier of the protocol.

```swift
#if DEBUG

open class DependencyDMock: DependencyD {
    internal let mocks = Members()
    internal class Members {
        internal var qux: MockMember<Qux, Qux> = .init()
    }
    internal var qux: Qux {
        get  {
            mocks.qux.getter()
        }
        set {
            mocks.qux.setter(newValue)
        }
    }
}

#endif
```